### PR TITLE
Fixed group-based area settings for AreaYouWroteTo

### DIFF
--- a/golded.spec
+++ b/golded.spec
@@ -1,4 +1,4 @@
-%define reldate 20230205
+%define reldate 20230214
 %define reltype C
 # may be one of: C (current), R (release), S (stable)
 

--- a/golded3/gepost.cpp
+++ b/golded3/gepost.cpp
@@ -389,6 +389,7 @@ static void MakeMsg3(int& mode, GMsg* msg)
             A->SaveMsg(GMSG_NEW|GMSG_NOLSTUPD, msg);
             A->Close();
             AA->Open();
+            AA->RandomizeData(mode);
             if(back)
                 memmove(msg->txt, back, mlen);
             msg->msgno = oldmsgno;

--- a/srcdate.h
+++ b/srcdate.h
@@ -1,3 +1,3 @@
 #ifndef __SRCDATE__
-#define __SRCDATE__ "20230205"
+#define __SRCDATE__ "20230214"
 #endif


### PR DESCRIPTION
Reload group-based area settings after carbon copy if AreaYouWroteTo is enabled.