### PR TITLE
fix buffer overrun when invalidate kludges on long lines

### DIFF
--- a/golded3/geline.cpp
+++ b/golded3/geline.cpp
@@ -3681,40 +3681,35 @@ void InvalidateControlInfo(GMsg* msg)
 {
 
     Line* line = msg->lin;
-    char buf[256];
-
     while(line)
     {
 
         if(not (line->type & (GLINE_TEAR | GLINE_ORIG)))
         {
-
-            strcpy(buf, line->txt.c_str());
-
+            bool invalidated = false;
             // Invalidate tearline
             if(not CFG->invalidate.tearline.first.empty())
-                doinvalidate(buf, CFG->invalidate.tearline.first.c_str(), CFG->invalidate.tearline.second.c_str(), true);
+                invalidated |= doinvalidate(line->txt, CFG->invalidate.tearline.first, CFG->invalidate.tearline.second, true);
             else
-                doinvalidate(buf, "---", "-+-", true);
+                invalidated |= doinvalidate(line->txt, "---", "-+-", true);
 
             // Invalidate originline
             if(not CFG->invalidate.origin.first.empty())
-                doinvalidate(buf, CFG->invalidate.origin.first.c_str(), CFG->invalidate.origin.second.c_str());
+                invalidated |= doinvalidate(line->txt, CFG->invalidate.origin.first.c_str(), CFG->invalidate.origin.second.c_str());
             else
-                doinvalidate(buf, " * Origin: ", " + Origin: ");
+                invalidated |= doinvalidate(line->txt, " * Origin: ", " + Origin: ");
 
             // Invalidate SEEN-BY's
             if(not CFG->invalidate.seenby.first.empty())
-                doinvalidate(buf, CFG->invalidate.seenby.first.c_str(), CFG->invalidate.seenby.second.c_str());
+                invalidated |= doinvalidate(line->txt, CFG->invalidate.seenby.first.c_str(), CFG->invalidate.seenby.second.c_str());
             else
-                doinvalidate(buf, "SEEN-BY: ", "SEEN+BY: ");
+                invalidated |= doinvalidate(line->txt, "SEEN-BY: ", "SEEN+BY: ");
 
-            if(stricmp(buf, line->txt.c_str()))
+            if(invalidated)
             {
                 line->type &= ~GLINE_KLUDGE;
                 line->kludge = 0;
                 line->color = C_READW;
-                line->txt = buf;
             }
 
         }

--- a/golded3/gepost.cpp
+++ b/golded3/gepost.cpp
@@ -1067,17 +1067,20 @@ void MakeMsg(int mode, GMsg* omsg, bool ignore_replyto)
                 }
                 else
                 {
-                    char* r;
+                    const char* r;
                     uint32_t number;
-                    char* ptr = msg->re;
+                    const char* ptr = msg->re;
                     do
                     {
-                        r = (char*)get_subject_re_info(ptr, number);
+                        r = get_subject_re_info(ptr, number);
                         if(r)
                             ptr = strskip_wht(r);
                     }
                     while(r);
-                    strcpy(msg->re, ptr);
+                    if (ptr != msg->re)
+                    {
+                        memmove(msg->re, ptr, strlen(ptr) + 1);
+                    }
                 }
                 strcpy(msg->ddom, omsg->odom);
                 if((mode == MODE_REPLYCOMMENT) and omsg->fwdorig.net)

--- a/golded3/geprot.h
+++ b/golded3/geprot.h
@@ -486,7 +486,7 @@ void  w_shadow();
 void  ZonegateIt(ftn_addr& gate, ftn_addr& orig, ftn_addr& dest);
 char* strtmp(const char* str);
 vattr quotecolor(const char* line);
-void  doinvalidate(char* text, const char* find, const char* replace, bool is_tearline = false);
+bool  doinvalidate(std::string& text, const std::string& find, const std::string& replace, bool is_tearline = false);
 bool find(const std::vector<const char *> &vec, const char *str);
 bool find(const std::vector<std::string> &vec, const std::string &str);
 vattr GetColorName(const char *name, Addr &addr, vattr color);

--- a/golded3/getpls.cpp
+++ b/golded3/getpls.cpp
@@ -897,36 +897,35 @@ int TemplateToText(int mode, GMsg* msg, GMsg* oldmsg, const char* tpl, int origa
                     if((mode == MODE_FORWARD) or (mode == MODE_CHANGE) or
                             (mode == MODE_WRITEHEADER) or (mode == MODE_WRITE))
                     {
-                        n = 0;
-                        while(oldmsg->line[n])
+                        for (size_t n = 0; oldmsg->line[n]; ++n)
                         {
                             if(oldmsg->line[n]->txt.c_str())
                             {
-                                strcpy(buf, oldmsg->line[n]->txt.c_str());
+                                std::string tmpLine = oldmsg->line[n]->txt;
                                 if(mode == MODE_FORWARD)
                                 {
                                     // Invalidate tearline
                                     if(not CFG->invalidate.tearline.first.empty())
-                                        doinvalidate(buf, CFG->invalidate.tearline.first.c_str(), CFG->invalidate.tearline.second.c_str(), true);
+                                        doinvalidate(tmpLine, CFG->invalidate.tearline.first, CFG->invalidate.tearline.second, true);
                                     // Invalidate originline
                                     if(not CFG->invalidate.origin.first.empty())
-                                        doinvalidate(buf, CFG->invalidate.origin.first.c_str(), CFG->invalidate.origin.second.c_str());
+                                        doinvalidate(tmpLine, CFG->invalidate.origin.first, CFG->invalidate.origin.second);
                                     // Invalidate SEEN-BY's
                                     if(not CFG->invalidate.seenby.first.empty())
-                                        doinvalidate(buf, CFG->invalidate.seenby.first.c_str(), CFG->invalidate.seenby.second.c_str());
+                                        doinvalidate(tmpLine, CFG->invalidate.seenby.first, CFG->invalidate.seenby.second);
                                     // Invalidate CC's
                                     if(not CFG->invalidate.cc.first.empty())
-                                        doinvalidate(buf, CFG->invalidate.cc.first.c_str(), CFG->invalidate.cc.second.c_str());
+                                        doinvalidate(tmpLine, CFG->invalidate.cc.first, CFG->invalidate.cc.second);
                                     // Invalidate XC's
                                     if(not CFG->invalidate.xc.first.empty())
-                                        doinvalidate(buf, CFG->invalidate.xc.first.c_str(), CFG->invalidate.xc.second.c_str());
+                                        doinvalidate(tmpLine, CFG->invalidate.xc.first, CFG->invalidate.xc.second);
                                     // Invalidate XP's
                                     if(not CFG->invalidate.xp.first.empty())
-                                        doinvalidate(buf, CFG->invalidate.xp.first.c_str(), CFG->invalidate.xp.second.c_str());
+                                        doinvalidate(tmpLine, CFG->invalidate.xp.first, CFG->invalidate.xp.second);
                                     // Invalidate kludge chars
-                                    strchg(buf, CTRL_A, '@');
+                                    strchg(tmpLine, CTRL_A, '@');
                                 }
-                                len = strlen(buf);
+                                len = tmpLine.size();
                                 size += len;
                                 if(msg_txt_realloc_cache >= (len+1))
                                 {
@@ -937,7 +936,7 @@ int TemplateToText(int mode, GMsg* msg, GMsg* oldmsg, const char* tpl, int origa
                                     msg_txt_realloc_cache += (size <= oldmsg_size) ? oldmsg_size : REALLOC_CACHE_SIZE;
                                     msg->txt = (char*)throw_realloc(msg->txt, size+10+msg_txt_realloc_cache);
                                 }
-                                strcpy(&(msg->txt[pos]), buf);
+                                strcpy(&(msg->txt[pos]), tmpLine.c_str());
                                 pos += len;
                                 if(oldmsg->line[n]->type & GLINE_HARD)
                                 {
@@ -956,7 +955,6 @@ int TemplateToText(int mode, GMsg* msg, GMsg* oldmsg, const char* tpl, int origa
                                     }
                                 }
                             }
-                            n++;
                         }
                     } // case TPLTOKEN_MESSAGE: if(....)
                     continue;

--- a/golded3/geutil2.cpp
+++ b/golded3/geutil2.cpp
@@ -167,17 +167,16 @@ int GetAkaNo(const ftn_addr& aka)
 
 //  ------------------------------------------------------------------
 
-void doinvalidate(char* text, const char* find, const char* replace, bool is_tearline)
+bool doinvalidate(std::string& text, const std::string& find, const std::string& replace, bool is_tearline)
 {
 
-    int n = strlen(find);
-    if(strnieql(text, find, n) and (not is_tearline or (text[n] == NUL) or isspace(text[n])))
+    const size_t n = find.size();
+    if(strieql(text.c_str(), find.c_str()) and (not is_tearline or (text.size() == n) or isspace(text[n])))
     {
-        char buf[256];
-
-        strcpy(buf, text);
-        strcpy(stpcpy(text, replace), &buf[n]);
+        text.replace(0, n, replace);
+        return true;
     }
+    return false;
 }
 
 


### PR DESCRIPTION
Only reproduced when terminal width is more that 256 symbols and line(s) longer than 256 chars. May not crash, but corrupts memory.