### PR TITLE
add severity to log records

### DIFF
--- a/golded3/gccfgg0.cpp
+++ b/golded3/gccfgg0.cpp
@@ -1494,7 +1494,7 @@ int ReadCfg(const char* cfgfile, int ignoreunknown)
         STD_PRINTNL("* Filename '" << cfgfile << "' too long (max " << GMAXPATH-1 << " characters).");
         LOG.ErrOpen();
         LOG.printf("! Unable to use configuration file because filename too long (see next line):");
-        LOG.printf("%s",cfgfile);
+        LOG.printf(": %s",cfgfile);
         cfgerrors++;
         return 0; // Error: can't use too long file name
     }

--- a/golded3/geline.cpp
+++ b/golded3/geline.cpp
@@ -2075,15 +2075,15 @@ chardo:
                     switch( errno )
                     {
                     case EINVAL:
-                        LOG.printf("An incomplete multibyte sequence has been encountered before:");
-                        LOG.printf("%s",sptr);
+                        LOG.printf("! An incomplete multibyte sequence has been encountered before:");
+                        LOG.printf("+ %s",sptr);
                     case EILSEQ:
-                        LOG.printf("An invalid multibyte sequence has been encountered in the input before:");
-                        LOG.printf("%s",sptr);
+                        LOG.printf("! An invalid multibyte sequence has been encountered in the input before:");
+                        LOG.printf("+ %s",sptr);
                     case E2BIG:
-                        LOG.printf("There is not sufficient destination size before '%s'", sptr);
+                        LOG.printf("! There is not sufficient destination size before '%s'", sptr);
                     default:
-                        LOG.printf("Unknown error %u in iconv() before %s", errno, sptr);
+                        LOG.printf("! Unknown error %u in iconv() before %s", errno, sptr);
                     }
                 }
             }
@@ -3367,9 +3367,9 @@ int LoadCharset(const char* imp, const char* exp, int query)
         iconv_close(iconv_cd);
     iconv_cd = iconv_open(exp, imp);
     if(iconv_cd != (iconv_t)(-1) )
-        LOG.printf("iconv is initialised to convert from %s to %s", imp, exp);
+        LOG.printf("+ iconv is initialised to convert from %s to %s", imp, exp);
     else
-        LOG.printf("Can't initialise iconv to convert from %s to %s", imp, exp);
+        LOG.printf("+ Can't initialise iconv to convert from %s to %s", imp, exp);
 #endif
 
     // Find and load charset table

--- a/golded3/gemsgs.cpp
+++ b/golded3/gemsgs.cpp
@@ -711,7 +711,7 @@ void TokenXlat(int mode, std::string &input, GMsg* msg, GMsg* oldmsg, int __orig
                     }
                 }
 #else
-                LOG.printf("Macros \"@uptime\" is not suppoted on platform %s!", __gver_platform__);
+                LOG.printf("! Macros \"@uptime\" is not suppoted on platform %s!", __gver_platform__);
 #endif
 
                 if( seconds+useconds>0 )
@@ -736,7 +736,7 @@ void TokenXlat(int mode, std::string &input, GMsg* msg, GMsg* oldmsg, int __orig
                 }
                 else
                 {
-                    LOG.printf("Can't determine uptime value, set @uptime empty.");
+                    LOG.printf("! Can't determine uptime value, set @uptime empty.");
                     tokenxchg(input, dst, "@uptime", "");
                 }
             }


### PR DESCRIPTION
When severity is not set, log records looks very weird in log file. Like this:
"C 20:18:27  n't initialise iconv to convert from KOI8-R 2 to KOI8-R"