### PR TITLE
Replace hardcoded value for IO Buffer with BUFSIZ

### DIFF
--- a/golded.spec
+++ b/golded.spec
@@ -1,4 +1,4 @@
-%define reldate 20231004
+%define reldate 20231008
 %define reltype C
 # may be one of: C (current), R (release), S (stable)
 

--- a/golded3/gcalst.cpp
+++ b/golded3/gcalst.cpp
@@ -166,7 +166,7 @@ void AreaList::WriteGoldLast()
     gfile fp(lst, "wb", CFG->sharemode);
     if (fp.isopen())
     {
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
         fp.Fwrite(&GOLDLAST_VER, sizeof(word));
         fp.Fwrite(AL.alistselections, sizeof(AL.alistselections));
 
@@ -212,7 +212,7 @@ void AreaList::ReadGoldLast()
     gfile fp(AddPath(CFG->goldpath, CFG->goldlast), "rb", CFG->sharemode);
     if (fp.isopen())
     {
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
         fp.Fread(&GOLDLAST_VER, sizeof(word));
 
         if (GOLDLAST_VER != CUR_GOLDLAST_VER)

--- a/golded3/gccfgg0.cpp
+++ b/golded3/gccfgg0.cpp
@@ -1520,7 +1520,7 @@ int ReadCfg(const char* cfgfile, int ignoreunknown)
             STD_PRINTNL("* Reading " << cfg);
 
         // Assign file buffer
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
         // Read each line
         while (fp.Fgets((val=buf), sizeof(buf)))

--- a/golded3/gclang.cpp
+++ b/golded3/gclang.cpp
@@ -687,7 +687,7 @@ void LoadLanguage(const char* file)
     gfile fp(AddPath(CFG->goldpath, file), "rt", CFG->sharemode);
     if (fp.isopen())
     {
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
         while (fp.Fgets((ptr=buf), sizeof(buf)))
         {
             line++;
@@ -745,7 +745,7 @@ bool ReadLangCfg()
     gfile fpi(cfgname, "rt", CFG->sharemode);
     if (fpi.isopen())
     {
-        fpi.SetvBuf(NULL, _IOFBF, 8192);
+        fpi.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << cfgname);
@@ -803,4 +803,3 @@ bool ReadLangCfg()
 
 
 //  ------------------------------------------------------------------
-

--- a/golded3/gcmisc.cpp
+++ b/golded3/gcmisc.cpp
@@ -44,7 +44,7 @@ int ReadHelpCfg(int force)
         gfile ifp(AddPath(CFG->goldpath, CFG->helpcfg.fn), "rb", CFG->sharemode);
         if (ifp.isopen())
         {
-            ifp.SetvBuf(NULL, _IOFBF, 8192);
+            ifp.SetvBuf(NULL, _IOFBF, BUFSIZ);
             gfile ofp(AddPath(CFG->goldpath, CFG->helpged), "wb", CFG->sharemode);
             if (ofp.isopen())
             {
@@ -54,7 +54,7 @@ int ReadHelpCfg(int force)
                 if (not quiet)
                     STD_PRINTNL("* Reading " << AddPath(CFG->goldpath, CFG->helpcfg.fn));
 
-                ofp.SetvBuf(NULL, _IOFBF, 8192);
+                ofp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
                 count = 0;
                 ifp.Rewind();

--- a/goldlib/gall/gfile.h
+++ b/goldlib/gall/gfile.h
@@ -168,7 +168,7 @@ public:
         rewind(fp);
     }
 
-    int     SetvBuf (char* __buf=NULL, int __type=_IOFBF, size_t __size=8192);
+    int     SetvBuf (char* __buf=NULL, int __type=_IOFBF, size_t __size=BUFSIZ);
     int     SetvBuf (size_t __size)
     {
         return SetvBuf(NULL, _IOFBF, __size);

--- a/goldlib/gcfg/gedacfg.cpp
+++ b/goldlib/gcfg/gedacfg.cpp
@@ -362,7 +362,7 @@ void gareafile::GetAreasBBS(char* name, char* origin)
     gfile fp(areafile, "rt", sharemode);
     if (fp.isopen())
     {
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << areafile);

--- a/goldlib/gcfg/gxcrash.cpp
+++ b/goldlib/gcfg/gxcrash.cpp
@@ -87,7 +87,7 @@ void gareafile::ReadCrashmailCfg(const char* file)
     gfile fp(file, "rt", sharemode);
     if (fp.isopen())
     {
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxdb.cpp
+++ b/goldlib/gcfg/gxdb.cpp
@@ -52,7 +52,7 @@ void gareafile::ReadDB130(char* /*tag*/, char* dbpath)
     gfile fp1(file1, "rb", sharemode);
     if (fp1.isopen())
     {
-        fp1.SetvBuf(NULL, _IOFBF, 8192);
+        fp1.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file1);
@@ -60,7 +60,7 @@ void gareafile::ReadDB130(char* /*tag*/, char* dbpath)
         gfile fp2(file2, "rb", sharemode);
         if (fp2.isopen())
         {
-            fp2.SetvBuf(NULL, _IOFBF, 8192);
+            fp2.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file2);
@@ -123,7 +123,7 @@ void gareafile::ReadDB1046(char* file, char* /*tag*/)
     gfile fp(file, "rb", sharemode);
     if (fp.isopen())
     {
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);
@@ -187,7 +187,7 @@ void gareafile::ReadDB1047A22(char* file, int reclen, char* /*tag*/)
         gfile fp(file, "rb", sharemode);
         if (fp.isopen())
         {
-            fp.SetvBuf(NULL, _IOFBF, 8192);
+            fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file);
@@ -252,7 +252,7 @@ void gareafile::ReadDB2011(char* file, int reclen, char* /*tag*/)
         gfile fp(file, "rb", sharemode);
         if (fp.isopen())
         {
-            fp.SetvBuf(NULL, _IOFBF, 8192);
+            fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxdutch.cpp
+++ b/goldlib/gcfg/gxdutch.cpp
@@ -71,7 +71,7 @@ void gareafile::ReadDutchie(char* tag)
     gfile fp(file, "rb", sharemode);
     if (fp.isopen())
     {
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxfd.cpp
+++ b/goldlib/gcfg/gxfd.cpp
@@ -129,7 +129,7 @@ void gareafile::ReadFrontDoor(char* tag)
     fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxfidpcb.cpp
+++ b/goldlib/gcfg/gxfidpcb.cpp
@@ -96,7 +96,7 @@ void gareafile::ReadFidoPCB(char* tag)
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxgecho.cpp
+++ b/goldlib/gcfg/gxgecho.cpp
@@ -364,7 +364,7 @@ void gareafile::ReadGEcho(char* tag)
                 fp = fsopen(file, "rb", sharemode);
                 if (fp)
                 {
-                    setvbuf(fp, NULL, _IOFBF, 8192);
+                    setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
                     if (not quiet)
                         STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxhpt.cpp
+++ b/goldlib/gcfg/gxhpt.cpp
@@ -181,7 +181,7 @@ void gareafile::ReadHPTFile(char* path, char* file, char* origin, int group)
     gfile fp(file, "rb", sharemode);
     if (fp.isopen())
     {
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gximail4.cpp
+++ b/goldlib/gcfg/gximail4.cpp
@@ -80,7 +80,7 @@ void gareafile::ReadIMail160(char* file, char* impath)
         fp = fsopen(file, "rb", sharemode);
         if (fp)
         {
-            setvbuf(fp, NULL, _IOFBF, 8192);
+            setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gximail5.cpp
+++ b/goldlib/gcfg/gximail5.cpp
@@ -90,7 +90,7 @@ void gareafile::ReadIMail170(char* file, char* impath)
         fp = fsopen(file, "rb", sharemode);
         if (fp)
         {
-            setvbuf(fp, NULL, _IOFBF, 8192);
+            setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gximail6.cpp
+++ b/goldlib/gcfg/gximail6.cpp
@@ -90,7 +90,7 @@ void gareafile::ReadIMail185(char* file, char* impath)
         fp = fsopen(file, "rb", sharemode);
         if (fp)
         {
-            setvbuf(fp, NULL, _IOFBF, 8192);
+            setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxlora.cpp
+++ b/goldlib/gcfg/gxlora.cpp
@@ -144,7 +144,7 @@ void gareafile::ReadLoraBBS(char* tag)
         fp.Fopen(_file, "rb");
         if (fp.isopen())
         {
-            fp.SetvBuf(NULL, _IOFBF, 8192);
+            fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << _file);

--- a/goldlib/gcfg/gxme2.cpp
+++ b/goldlib/gcfg/gxme2.cpp
@@ -65,7 +65,7 @@ void gareafile::ReadME2(char* tag)
             fp = fsopen(file, "rt", sharemode);
             if (fp)
             {
-                setvbuf(fp, NULL, _IOFBF, 8192);
+                setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
                 if (not quiet)
                     STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxopus.cpp
+++ b/goldlib/gcfg/gxopus.cpp
@@ -86,7 +86,7 @@ void gareafile::ReadOpus(char* tag)
         fp = fsopen(file, "rb", sharemode);
         if (fp)
         {
-            setvbuf(fp, NULL, _IOFBF, 8192);
+            setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file);
@@ -148,7 +148,7 @@ void gareafile::ReadOpus(char* tag)
                 fp = fsopen(file, "rb", sharemode);
                 if (fp)
                 {
-                    setvbuf(fp, NULL, _IOFBF, 8192);
+                    setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
                     if (not quiet)
                         STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxprobrd.cpp
+++ b/goldlib/gcfg/gxprobrd.cpp
@@ -100,7 +100,7 @@ void gareafile::ReadProBoard(char* tag)
     fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxqecho.cpp
+++ b/goldlib/gcfg/gxqecho.cpp
@@ -46,7 +46,7 @@ void gareafile::ReadQEchoFile(char* file, char* origin)
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxqfront.cpp
+++ b/goldlib/gcfg/gxqfront.cpp
@@ -86,7 +86,7 @@ void gareafile::ReadQFront(char* tag)
     fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxra.cpp
+++ b/goldlib/gcfg/gxra.cpp
@@ -103,7 +103,7 @@ void gareafile::ReadRemoteAccess(char* tag)
         fp = fsopen(file, "rb", sharemode);
         if (fp)
         {
-            setvbuf(fp, NULL, _IOFBF, 8192);
+            setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxraecho.cpp
+++ b/goldlib/gcfg/gxraecho.cpp
@@ -94,7 +94,7 @@ void gareafile::ReadRaEcho(char* tag)
     fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxspace.cpp
+++ b/goldlib/gcfg/gxspace.cpp
@@ -84,7 +84,7 @@ void gareafile::ReadSpaceAr(const char* file)
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);
@@ -186,7 +186,7 @@ void gareafile::ReadSpaceNtm(const char* file)
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);
@@ -256,7 +256,7 @@ void gareafile::ReadSpaceCtl(const char* file)
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxsquish.cpp
+++ b/goldlib/gcfg/gxsquish.cpp
@@ -57,7 +57,7 @@ void gareafile::ReadSquishFile(char* path, char* file, char* options, char* orig
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxsync.cpp
+++ b/goldlib/gcfg/gxsync.cpp
@@ -97,7 +97,7 @@ void gareafile::ReadSynchronet(char* tag)
     FILE* in = fsopen(file, "rb", sharemode);
     if (in)
     {
-        setvbuf(in, NULL, _IOFBF, 8192);
+        setvbuf(in, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxtimed.cpp
+++ b/goldlib/gcfg/gxtimed.cpp
@@ -78,7 +78,7 @@ void gareafile::ReadTimedFile(char* path, char* file, char* options, char* origi
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxtmail.cpp
+++ b/goldlib/gcfg/gxtmail.cpp
@@ -54,7 +54,7 @@ void gareafile::ReadTmailFile(char* file, char* origin)
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxts.cpp
+++ b/goldlib/gcfg/gxts.cpp
@@ -126,7 +126,7 @@ void gareafile::ReadTosScan(char* tag)
         fp = fsopen(file, "rb", sharemode);
         if (fp)
         {
-            setvbuf(fp, NULL, _IOFBF, 8192);
+            setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
             if (not quiet)
                 STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxxbbs.cpp
+++ b/goldlib/gcfg/gxxbbs.cpp
@@ -62,7 +62,7 @@ void gareafile::ReadAdeptXbbsFile(char* path, char* file)
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gcfg/gxxmail.cpp
+++ b/goldlib/gcfg/gxxmail.cpp
@@ -86,7 +86,7 @@ void gareafile::ReadxMailFile(char* file)
     FILE* fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);
@@ -176,7 +176,7 @@ void gareafile::ReadXMail(char* tag)
     fp = fsopen(file, "rb", sharemode);
     if (fp)
     {
-        setvbuf(fp, NULL, _IOFBF, 8192);
+        setvbuf(fp, NULL, _IOFBF, BUFSIZ);
 
         if (not quiet)
             STD_PRINTNL("* Reading " << file);

--- a/goldlib/gmb3/gmopcbd1.cpp
+++ b/goldlib/gmb3/gmopcbd1.cpp
@@ -90,7 +90,7 @@ void PcbInit(const char* path, int userno)
         // Get some paths/filenames
         int _line = 0;
         char _buf[256];
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
         while (fp.Fgets(_buf, sizeof(_buf)))
         {
             _line++;
@@ -113,7 +113,7 @@ void PcbInit(const char* path, int userno)
 
         // Get board numbers for lastread indexing in the userfiles
         word _recsize = 0;
-        fp.SetvBuf(NULL, _IOFBF, 8192);
+        fp.SetvBuf(NULL, _IOFBF, BUFSIZ);
         fp.Fread(&_recsize, 2);
         if (_recsize)
         {

--- a/srcdate.h
+++ b/srcdate.h
@@ -1,3 +1,3 @@
 #ifndef __SRCDATE__
-#define __SRCDATE__ "20231004"
+#define __SRCDATE__ "20231008"
 #endif


### PR DESCRIPTION
From the docs:
"The default buffer size BUFSIZ is expected to be the most efficient buffer size for file I/O on the implementation, but POSIX fstat often provides a better estimate."