### PR TITLE
Clean OBJ path and LIB path in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ all: sourcelists
 clean:
 	@$(SHELL) -ec 'for i in $(foreach dir,$(LIBS),goldlib/$(dir)); do cd $$i; $(MAKE) clean; cd ../..; done'
 	@$(SHELL) -ec 'for i in $(EXECUTABLES); do cd $$i; $(MAKE) clean; cd ..; done'
-	@-rm -f $(OBJPATH)/$(PLATFORM)/source.lst
+	@-rm -rf $(OBJPATH)
+	@-rm -rf $(LIBPATH)
 
 distclean:
 	@-cd $(BIN); rm -f $(EXECUTABLES)


### PR DESCRIPTION
When files renamed or deleted, obj and libs don't get deleted. 
Now `make clean` ensures all LIBs and OBj files are deleted from the last build 

I got this error before 
```
/usr/bin/ld: ../lib/lnx/libhunspell.a(suggmgr.o): in function `SuggestMgr::SuggestMgr(char const*, int, AffixMgr*)':
/home/shtirlic/projects/golded-plus/goldlib/hunspell/suggmgr.cxx:38:(.text+0x62): undefined reference to `AffixMgr::get_encoding()'
/usr/bin/ld: /home/shtirlic/projects/golded-plus/goldlib/hunspell/suggmgr.cxx:39:(.text+0x6d): undefined reference to `get_current_cs(char const
*)'
```


