### PR TITLE
revert "zero conversion" workaround

### DIFF
--- a/golded.spec
+++ b/golded.spec
@@ -1,4 +1,4 @@
-%define reldate 20231030
+%define reldate 20231106
 %define reltype C
 # may be one of: C (current), R (release), S (stable)
 

--- a/golded3/geline.cpp
+++ b/golded3/geline.cpp
@@ -3407,11 +3407,6 @@ int LoadCharset(int index)
 int LoadCharset(const char* imp, const char* exp)
 {
 
-    if (IsZeroConversion(imp, exp))
-    {
-        return LoadCharset(-1);
-    }
-
     int n;
 
 #ifdef HAS_ICONV
@@ -3452,6 +3447,12 @@ int LoadCharset(const char* imp, const char* exp)
     throw_release(CharTable);
     ChsTP = NULL;
     current_table = -1;
+
+    if (IsZeroConversion(imp, exp))
+    {
+        return LoadCharset(-1);
+    }
+
     return 0;
 }
 

--- a/srcdate.h
+++ b/srcdate.h
@@ -1,3 +1,3 @@
 #ifndef __SRCDATE__
-#define __SRCDATE__ "20231030"
+#define __SRCDATE__ "20231106"
 #endif


### PR DESCRIPTION
If one-to-one charset conversion table is setup in configuration use it instead of zero conversion algorithm first.