### PR TITLE
fix crash when reading removed message in Squish

### DIFF
--- a/golded.spec
+++ b/golded.spec
@@ -1,4 +1,4 @@
-%define reldate 20240306
+%define reldate 20240309
 %define reltype C
 # may be one of: C (current), R (release), S (stable)
 

--- a/goldlib/gmb3/gmosqsh3.cpp
+++ b/goldlib/gmb3/gmosqsh3.cpp
@@ -69,6 +69,14 @@ int SquishArea::load_message(int __mode, gmsg* __msg, SqshHdr& __hdr)
         return false;
     }
 
+    // Check if this frame is normal
+    if (_frm.type != SQFRAME_NORMAL)
+    {
+        WideLog->printf("! SquishArea::load_message: reln=%d frame type=%d is not normal", _reln, (int)_frm.type);
+        GFTRK(0);
+        return false;
+    }
+
     // Load the message header
     __hdr = SqshHdr();
     rwresult = read(_fhsqd, &__hdr, sizeof(SqshHdr));
@@ -87,10 +95,8 @@ int SquishArea::load_message(int __mode, gmsg* __msg, SqshHdr& __hdr)
     // Read control info and message text
     if(__mode & GMSG_TXT)
     {
-
-        if(_frm.length)
+        if(_frm.ctlsize+_frm.totsize >= sizeof(SqshHdr))
         {
-
             // Allocate memory for kludges and message text, then read control info
             char* _dest = __msg->txt = (char*)throw_calloc(1, (uint)(1+_frm.ctlsize+_frm.totsize-sizeof(SqshHdr)));
             char* _src = _dest + (uint)_frm.ctlsize;

--- a/srcdate.h
+++ b/srcdate.h
@@ -1,3 +1,3 @@
 #ifndef __SRCDATE__
-#define __SRCDATE__ "20240306"
+#define __SRCDATE__ "20240309"
 #endif


### PR DESCRIPTION
Fixed a bug/crash when GoldED opens a message in the current area which has been deleted outside of GoldED.

This bug leads to enormous memory allocation size and GoldED will either be killed (OOMKiller) or exit with the Squish msgbase corruption message in log.