### PR TITLE
Fix line truncate error on long lines from nodelist

### DIFF
--- a/goldlib/gall/gstrutil.cpp
+++ b/goldlib/gall/gstrutil.cpp
@@ -876,9 +876,6 @@ int gsprintf(TCHAR* buffer, size_t sizeOfBuffer, const TCHAR* __file, int __line
         }
         else if (ret >= sizeOfBuffer)
         {
-//            if (sizeOfBuffer>17) strcpy(buffer, " ERROR, see log! ");
-//            else if (sizeOfBuffer>7) strcpy(buffer," ERROR ");
-//            else buffer[sizeOfBuffer-1] = '\0';
             buffer[sizeOfBuffer-1] = '\0';
             LOG.printf("! %s", gerrinfo("Line trunkated", __file, __line));
             LOG.printf("! gsprintf(buffer,%i,%s,...): line trunkated to buffer size (need %i bytes).", sizeOfBuffer, format, ret);

--- a/goldlib/gall/gstrutil.cpp
+++ b/goldlib/gall/gstrutil.cpp
@@ -877,7 +877,7 @@ int gsprintf(TCHAR* buffer, size_t sizeOfBuffer, const TCHAR* __file, int __line
         else if (ret >= sizeOfBuffer)
         {
             buffer[sizeOfBuffer-1] = '\0';
-            LOG.printf("! %s", gerrinfo("Line trunkated", __file, __line));
+            LOG.printf("! %s", gerrinfo("Line truncated", __file, __line));
             LOG.printf("! gsprintf(buffer,%i,%s,...): line trunkated to buffer size (need %i bytes).", sizeOfBuffer, format, ret);
         }
 

--- a/goldlib/gall/gstrutil.cpp
+++ b/goldlib/gall/gstrutil.cpp
@@ -878,7 +878,7 @@ int gsprintf(TCHAR* buffer, size_t sizeOfBuffer, const TCHAR* __file, int __line
         {
             buffer[sizeOfBuffer-1] = '\0';
             LOG.printf("! %s", gerrinfo("Line truncated", __file, __line));
-            LOG.printf("! gsprintf(buffer,%i,%s,...): line trunkated to buffer size (need %i bytes).", sizeOfBuffer, format, ret);
+            LOG.printf("! gsprintf(buffer,%i,%s,...): line truncated to buffer size (need %i bytes).", sizeOfBuffer, format, ret);
         }
 
 #   else

--- a/goldlib/gall/gstrutil.cpp
+++ b/goldlib/gall/gstrutil.cpp
@@ -876,11 +876,12 @@ int gsprintf(TCHAR* buffer, size_t sizeOfBuffer, const TCHAR* __file, int __line
         }
         else if (ret >= sizeOfBuffer)
         {
-            if (sizeOfBuffer>17) strcpy(buffer, " ERROR, see log! ");
-            else if (sizeOfBuffer>7) strcpy(buffer," ERROR ");
-            else buffer[sizeOfBuffer-1] = '\0';
-            LOG.printf("! %s", gerrinfo("Memory error", __file, __line));
-            LOG.printf("! gsprintf(buffer,%i,%s,...): buffer overflow (need %i bytes).", sizeOfBuffer, format, ret);
+//            if (sizeOfBuffer>17) strcpy(buffer, " ERROR, see log! ");
+//            else if (sizeOfBuffer>7) strcpy(buffer," ERROR ");
+//            else buffer[sizeOfBuffer-1] = '\0';
+			buffer[sizeOfBuffer-1] = '\0';
+            LOG.printf("! %s", gerrinfo("Line trunkated", __file, __line));
+            LOG.printf("! gsprintf(buffer,%i,%s,...): line trunkated to buffer size (need %i bytes).", sizeOfBuffer, format, ret);
         }
 
 #   else

--- a/goldlib/gall/gstrutil.cpp
+++ b/goldlib/gall/gstrutil.cpp
@@ -879,7 +879,7 @@ int gsprintf(TCHAR* buffer, size_t sizeOfBuffer, const TCHAR* __file, int __line
 //            if (sizeOfBuffer>17) strcpy(buffer, " ERROR, see log! ");
 //            else if (sizeOfBuffer>7) strcpy(buffer," ERROR ");
 //            else buffer[sizeOfBuffer-1] = '\0';
-			buffer[sizeOfBuffer-1] = '\0';
+            buffer[sizeOfBuffer-1] = '\0';
             LOG.printf("! %s", gerrinfo("Line trunkated", __file, __line));
             LOG.printf("! gsprintf(buffer,%i,%s,...): line trunkated to buffer size (need %i bytes).", sizeOfBuffer, format, ret);
         }


### PR DESCRIPTION
Changes to gstrutil.cpp in vsnprintf usage - no error on string truncate.