### PR TITLE
Fix windows builds for long nodelist strings

### DIFF
--- a/golded.spec
+++ b/golded.spec
@@ -1,4 +1,4 @@
-%define reldate 20250401
+%define reldate 20250407
 %define reltype C
 # may be one of: C (current), R (release), S (stable)
 

--- a/goldlib/gall/gstrutil.cpp
+++ b/goldlib/gall/gstrutil.cpp
@@ -837,16 +837,14 @@ int gsprintf(TCHAR* buffer, size_t sizeOfBuffer, const TCHAR* __file, int __line
         ret = _vsnprintf(b1, sizeOfBuffer+1, format, argptr);
         if (ret == -1 || ret >= sizeOfBuffer) // Microsoft implementation returns -1 when buffer overflow.
         {
+            if (ret < 0 && errno != EINVAL)
+				ret = _vscprintf(format, argptr); //only for LOG message - symbols count
+
             strncpy(buffer,b1,endOfBuffer);
             buffer[endOfBuffer] = '\0';  // Microsoft implementation don't write final '\0' when buffer full.
-            if (b1[sizeOfBuffer] && strlen(buffer)>=endOfBuffer)
-            {
-                LOG.printf("! %s", gerrinfo("Memory error", __file, __line));
-                LOG.printf("! gsprintf(buffer,%i,%s,...): buffer overflow, result in next line:", sizeOfBuffer, format);
-                LOG.printf("! %s", buffer);
-                if (sizeOfBuffer>17) memcpy(buffer, " ERROR, see log! ", 17);
-                else if (sizeOfBuffer>7) memcpy(buffer," ERROR ", 7);
-            }
+
+            LOG.printf("! %s", gerrinfo("Line truncated", __file, __line));
+            LOG.printf("! gsprintf(buffer,%i,%s,...): line truncated to buffer size (need %i bytes).", sizeOfBuffer, format, ret);
         }
         else if (ret < 0)
         {

--- a/srcdate.h
+++ b/srcdate.h
@@ -1,3 +1,3 @@
 #ifndef __SRCDATE__
-#define __SRCDATE__ "20250401"
+#define __SRCDATE__ "20250407"
 #endif


### PR DESCRIPTION
WinSDK std library _vsnprintf behave different from *nixes:
it returns -1 on potential overflow with no errno.
